### PR TITLE
limit attributes for tracks

### DIFF
--- a/geo/exactEarth/Ship_Tracks.ipynb
+++ b/geo/exactEarth/Ship_Tracks.ipynb
@@ -53,7 +53,7 @@
     "t2 = np.datetime64('2019-08-31T00:00:00')\n",
     "\n",
     "with tiledb.SparseArray(tiledb_mmsi_uri) as arr:\n",
-    "    pts = arr.multi_index[t1:t2, 308371000]\n",
+    "    pts = arr.query(attrs=['latitude', 'longitude']).multi_index[t1:t2, 308371000]\n",
     "\n",
     "print(f\"Retrieved {len(pts['longitude'])} points\")\n",
     "    \n",


### PR DESCRIPTION
Limits the attributes selected when creating the vessel tracks.