### PR TITLE
Add create_dataset() To 02-vcf-python.ipynb

### DIFF
--- a/genomics/02-vcf-python.ipynb
+++ b/genomics/02-vcf-python.ipynb
@@ -105,6 +105,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "small_ds.create_dataset()\n",
     "small_ds.ingest_samples(local_vcfs)"
    ]
   },
@@ -1260,7 +1261,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1274,7 +1275,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Before the call to the .ingest_samples() function, the .create_dataset() function needed to be called, before any samples could be ingested. This will allow proper ingestion of samples. 